### PR TITLE
Topic/2025.0/merge roslyn 4.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,12 @@ jobs:
           ./.build-cache
         key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
-    - name: Stop if build cache hit
+    - name: Check for cache hit and conditionally fail job
       if: steps.cache-build.outputs.cache-hit == 'true'
+      shell: bash
       run: |
-        echo "Build cache hit, skipping build."
-        exit 0
-
+        echo "Exiting job early due to cache hit."
+        exit 78
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,77 +66,79 @@ jobs:
           ./.build-cache
         key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
-    - name: Check for cache hit and conditionally fail job
-      if: steps.cache-build.outputs.cache-hit == 'true'
-      shell: bash
-      run: |
-        echo "Exiting job early due to cache hit."
-        exit 78
-
     - name: Checkout
       uses: actions/checkout@v4
+      if: steps.cache-build.outputs.cache-hit != 'true'
       with:
         fetch-depth: 0
 
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
       id: setup-dotnet-eng
+      if: steps.cache-build.outputs.cache-hit != 'true'
       with:
         dotnet-version: 9.0.200
 
     - name: Set the .NET SDK Version
       shell: pwsh
+      if: steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 set-sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
 
     - name: Configure the dependency to Metalama
       shell: pwsh
+      if: steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 dependencies set BuildServer Metalama --branch ${{github.ref_name}} --nologo
 
     - name: Install Java
-      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && steps.cache-build.outputs.cache-hit != 'true'
       uses: actions/setup-java@v4
       with:
         distribution: 'microsoft'
         java-version: ${{ matrix.dotnet-version == '6.0.4xx' && '11' || '17' }} # error XA0030: Building with JDK version `21.0.2` is not supported. Please install JDK version `11.0`.
 
     - name: Install Android SDK
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15') && steps.cache-build.outputs.cache-hit != 'true'
       uses: android-actions/setup-android@v3
       with:
           cmdline-tools-version: ${{ matrix.dotnet-version == '6.0.4xx' && '9862592' || '10406996' }} # Based on the Java version installed above. See https://github.com/android-actions/setup-android?tab=readme-ov-file#sdk-version-selection
   
     - name: Install Android SDK Tools
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
       run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
 
     - name: Install .NET Workloads
-      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor')  && steps.cache-build.outputs.cache-hit != 'true'
       shell: pwsh
       run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' || 'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' || '' }}
 
     - name: Set ref version for Assembly Locator
       shell: pwsh
+      if:  steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 set-ref-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
 
     - name: Create Project
       shell: pwsh
+      if:  steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 create-project ${{ matrix.project-type }} --nologo
 
     - name: Build
       shell: pwsh
+      if:  steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 build --nologo
 
     - name: Verify Transformations
       shell: pwsh
+      if:  steps.cache-build.outputs.cache-hit != 'true'
       run: ./Build.ps1 verify-transformations --nologo
 
     # Create build cache marker file
     - name: Mark build cache as successful
+      if: steps.cache-build.outputs.cache-hit != 'true'
       run: echo Success > ./.build-cache
 
     # Save build cache after successful build
     - name: Save build cache
-      if: success()
+      if: success() && steps.cache-build.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,11 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
         dotnet-quality: 'daily' # Use the daily build, so we find potential issues early.
 
-    - name: Set The .NET SDK Version
+    - name: Configure the dependency to Metalama
+      shell: pwsh
+      run: ./Build.ps1 dependencies set Metalama BuildServer --branch ${{github.ref_name}}
+
+    - name: Set the .NET SDK Version
       shell: pwsh
       run: ./Build.ps1 set-sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,9 @@ jobs:
     - name: Install Xcode
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
       run: |
+        sudo xcode-select --install
         sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+        xcrun --find actool
         echo "/Applications/Xcode.app/Contents/Developer/usr/bin" >> $GITHUB_PATH
 
     - name: Install .NET Workloads

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Stop if build cache hit
       if: steps.cache-build.outputs.cache-hit == 'true'
@@ -75,8 +75,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       id: setup-dotnet
       with:
-        dotnet-version: ${{ steps.parse-dotnet.outputs.version }}
-        dotnet-quality: ${{ steps.parse-dotnet.outputs.quality }}
+        dotnet-version: ${{ steps.parse-dotnet.outputs.dotnet-version }}
+        dotnet-quality: ${{ steps.parse-dotnet.outputs.dotnet-quality }}
 
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
@@ -140,7 +140,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,15 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15]
-        dotnet: ['8.x:ga', '8.x:daily', '9.0.1xx:ga', '9.0.2xx:ga', '9.0.3xx:daily', '9.0.x:daily', '9.0.x:ga']
-        project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
+        #os: [ubuntu-latest, windows-latest, macos-15]
+        #dotnet: ['8.x:ga', '8.x:daily', '9.0.1xx:ga', '9.0.2xx:ga', '9.0.3xx:daily', '9.0.x:daily', '9.0.x:ga']
+        #project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
+
+        os: [macos-15]
+        dotnet: ['9.0.x:ga']
+        project-type: ['maui'] 
+
+
         configuration: [Debug]
         exclude:
           - project-type: winforms # N/A

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,10 +108,9 @@ jobs:
     - name: Install Xcode
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
       run: |
-        sudo xcode-select --install
         sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
         xcrun --find actool
-        echo "/Applications/Xcode.app/Contents/Developer/usr/bin" >> $GITHUB_PATH
+        xcode-select -p
 
     - name: Install .NET Workloads
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor')  && steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
-        dotnet: ['8.0.1xx:ga', '8.0.2xx:ga', '8.0.3xx:ga', '8.0.4xx:ga', '8.0.x:preview', '9.0.1xx:ga', '9.0.2xx:preview', '9.0.x:preview']
+        dotnet: ['8.x:ga', '8.x:preview', '9.0.1xx:ga', '9.0.2xx:preview', '9.0.x:preview']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
@@ -40,11 +40,6 @@ jobs:
     #  METALAMA_DIAGNOSTICS: '{"logging": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": true,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false},"trace": {"*": true},"stopLoggingAfterHours": 2.0},"debugging": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false}},"crashDumps": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false},"exceptionTypes": ["*"]},"profiling": {"kind": "performance","processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false}}}'
 
     steps:
-    # Needed only locally
-    #- name: Install PowerShell
-    #  uses: cakhanif/action-install-powershell@v1
-    # Restore build cache if available
-
 
     - name: Parse .NET version and quality
       id: parse-dotnet
@@ -135,7 +130,11 @@ jobs:
       shell: pwsh
       run: ./Build.ps1 verify-transformations --nologo
 
-          # Save build cache after successful build
+    # Create build cache marker file
+    - name: Mark build cache as successful
+      run: echo Success > ./.build-cache
+
+    # Save build cache after successful build
     - name: Save build cache
       if: success()
       uses: actions/cache/save@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - project-type: wpf # N/A
             os: macos-15
       fail-fast: false # Don't stop other jobs if one fails.
+      max-parallel: 8 # Give a chance to stop early when we run manually.
 
     timeout-minutes: 60
 
@@ -77,22 +78,19 @@ jobs:
       with:
         fetch-depth: 0
 
-   
-
-
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
       id: setup-dotnet-eng
       with:
         dotnet-version: 9.0.200
 
-    - name: Configure the dependency to Metalama
-      shell: pwsh
-      run: ./Build.ps1 dependencies set BuildServer Metalama --branch ${{github.ref_name}} --nologo
-
     - name: Set the .NET SDK Version
       shell: pwsh
       run: ./Build.ps1 set-sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
+
+    - name: Configure the dependency to Metalama
+      shell: pwsh
+      run: ./Build.ps1 dependencies set BuildServer Metalama --branch ${{github.ref_name}} --nologo
 
     - name: Install Java
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,7 @@ jobs:
       TEAMCITY_CLOUD_TOKEN: ${{ secrets.TEAMCITY_CLOUD_TOKEN }}
       ConsoleAnsi: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15') && 'No' || 'Detect' }} # https://github.com/orgs/community/discussions/136868
       MetalamaAssemblyLocatorHooksDirectory: '../..'
-    #  METALAMA_TEMP: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15') && '/tmp' || '' }}
-    #  METALAMA_DIAGNOSTICS: '{"logging": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": true,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false},"trace": {"*": true},"stopLoggingAfterHours": 2.0},"debugging": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false}},"crashDumps": {"processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false},"exceptionTypes": ["*"]},"profiling": {"kind": "performance","processes": {"BackstageWorker": false,"DevEnv": false,"LinqPad": false,"TestHost": false,"RoslynCodeAnalysisService": false,"OmniSharp": false,"Rider": false,"Other": false,"ResharperTestRunner": false,"Compiler": false,"BackstageDesktopWindows": false,"VisualStudioMac": false,"LanguageServer": false,"CodeLensService": false,"DotNetTool": false}}}'
+      CacheKeyPrefix: '100' # Increase this value to invalidate the cache.
 
     steps:
 
@@ -64,7 +63,7 @@ jobs:
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ env.CacheKeyPrefix }}-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -146,7 +145,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ env.CacheKeyPrefix }}-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
             dotnet-version: '8.0.4xx'
           - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
             dotnet-version: '9.0.1xx'
+          - project-type: maui # Interceptors not supported before Metalama 2025.0.
+            dotnet-version: '9.0.1xx'
+          - project-type: maui-blazor # Interceptors not supported before Metalama 2025.0.
+            dotnet-version: '9.0.1xx'
           # - project-type: maui # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
           #   dotnet-version: '9.0.1xx'
           # - project-type: maui-blazor # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
@@ -122,6 +126,21 @@ jobs:
     #   if: matrix.dotnet-version == '9.0.1xx' && matrix.project-type == 'blazorwasm'
     #   shell: pwsh
     #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n dotnet9 --configfile ./nuget.config
+
+    - name: Add .NET 6 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+      shell: pwsh
+      run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -n dotnet6 --configfile ./nuget.config
+
+    - name: Add .NET 7 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
+      shell: pwsh
+      run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json -n dotnet7 --configfile ./nuget.config
+
+    - name: Add .NET 8 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
+      shell: pwsh
+      run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json -n dotnet8 --configfile ./nuget.config
 
     - name: Install .NET Workloads
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,25 @@ jobs:
     #- name: Install PowerShell
     #  uses: cakhanif/action-install-powershell@v1
     # Restore build cache if available
+
+
+    - name: Parse .NET version and quality
+      id: parse-dotnet
+      run: |
+        DOTNET_VERSION="${{ matrix.dotnet }}"
+        DOTNET_VERSION="${DOTNET_VERSION%,*}"
+        DOTNET_QUALITY="${{ matrix.dotnet }}"
+        DOTNET_QUALITY="${DOTNET_QUALITY#*,}"
+        echo "version=$DOTNET_VERSION" >> $GITHUB_OUTPUT
+        echo "quality=$DOTNET_QUALITY" >> $GITHUB_OUTPUT
+
     - name: Restore build cache
       id: cache-build
       uses: actions/cache@v4
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ matrix.dotnet }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ steps.setup-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Stop if build cache hit
       if: steps.cache-build.outputs.cache-hit == 'true'
@@ -64,15 +76,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Parse .NET version and quality
-      id: parse-dotnet
-      run: |
-        DOTNET_VERSION="${{ matrix.dotnet }}"
-        DOTNET_VERSION="${DOTNET_VERSION%,*}"
-        DOTNET_QUALITY="${{ matrix.dotnet }}"
-        DOTNET_QUALITY="${DOTNET_QUALITY#*,}"
-        echo "version=$DOTNET_VERSION" >> $GITHUB_OUTPUT
-        echo "quality=$DOTNET_QUALITY" >> $GITHUB_OUTPUT
+   
 
     - name: Install .NET For The Test
       uses: actions/setup-dotnet@v4
@@ -139,9 +143,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ matrix.dotnet }}-${{ matrix.project-type }}-${{ matrix.configuration }}
-
-
+        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ steps.setup-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx' ]
-        project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
+        dotnet-version: ['8.0.4xx' ] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx' ]
+        project-type: ['maui', 'maui-blazor'] # ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
           - project-type: maui # N/A
@@ -105,47 +105,52 @@ jobs:
       shell: pwsh
       run: ./Build.ps1 set-sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
 
-    - name: Install Java
-      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'microsoft'
-        java-version: ${{ matrix.dotnet-version == '6.0.4xx' && '11' || '21' }} # error XA0030: Building with JDK version `21.0.2` is not supported. Please install JDK version `11.0`.
+    # - name: Install Java
+    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+    #   uses: actions/setup-java@v4
+    #   with:
+    #     distribution: 'microsoft'
+    #     java-version: ${{ matrix.dotnet-version == '6.0.4xx' && '11' || '21' }} # error XA0030: Building with JDK version `21.0.2` is not supported. Please install JDK version `11.0`.
 
-    - name: Install Android SDK
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
-      uses: android-actions/setup-android@v3
-      with:
-          cmdline-tools-version: ${{ matrix.dotnet-version == '6.0.4xx' && '9862592' || '10406996' }} # Based on the Java version installed above. See https://github.com/android-actions/setup-android?tab=readme-ov-file#sdk-version-selection
+    # - name: Install Android SDK
+    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
+    #   uses: android-actions/setup-android@v3
+    #   with:
+    #       cmdline-tools-version: ${{ matrix.dotnet-version == '6.0.4xx' && '9862592' || '10406996' }} # Based on the Java version installed above. See https://github.com/android-actions/setup-android?tab=readme-ov-file#sdk-version-selection
   
-    - name: Install Android SDK Tools
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
-      run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
+    # - name: Install Android SDK Tools
+    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
+    #   run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
 
     # - name: Add NuGet Feed # https://github.com/dotnet/sdk/issues/43050 TODO: Remove after .NET 9 GA
     #   if: matrix.dotnet-version == '9.0.1xx' && matrix.project-type == 'blazorwasm'
     #   shell: pwsh
     #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n dotnet9 --configfile ./nuget.config
 
-    - name: Add .NET 6 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+    # - name: Add .NET 6 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+    #   shell: pwsh
+    #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -n dotnet6 --configfile ./nuget.config
+
+    # - name: Add .NET 7 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
+    #   shell: pwsh
+    #   run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json -n dotnet7 --configfile ./nuget.config
+
+    # - name: Add .NET 8 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
+    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
+    #   shell: pwsh
+    #   run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json -n dotnet8 --configfile ./nuget.config
+
+    # - name: Install .NET Workloads
+    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+    #   shell: pwsh
+    #   run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' ||  'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' ||  '' }}
+
+    - name: Install MAUI dependencies
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
       shell: pwsh
-      run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -n dotnet6 --configfile ./nuget.config
-
-    - name: Add .NET 7 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
-      shell: pwsh
-      run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json -n dotnet7 --configfile ./nuget.config
-
-    - name: Add .NET 8 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
-      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
-      shell: pwsh
-      run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json -n dotnet8 --configfile ./nuget.config
-
-    - name: Install .NET Workloads
-      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
-      shell: pwsh
-      run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' ||  'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' ||  '' }}
+      run: dotnet dotnet tool install -g Redth.Net.Maui.Check && maui-check --fix --non-interactive --ci
 
     - name: Set ref version for Assembly Locator
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,9 @@ jobs:
 
     - name: Install Xcode
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
-      run: sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+      run: |
+        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+        echo "/Applications/Xcode.app/Contents/Developer/usr/bin" >> $GITHUB_PATH
 
     - name: Install .NET Workloads
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor')  && steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
         xcrun --find actool
-        xcode-select -p
+        echo "/Applications/Xcode_16.app/Contents/Developer/usr/bin" >> $GITHUB_PATH
 
     - name: Install .NET Workloads
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor')  && steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
-        dotnet: ['8.0.1xx,ga', '8.0.2xx,ga', '8.0.3xx,ga', '8.0.4xx,ga', '8.0.x,preview', '9.0.1xx,ga', '9.0.2xx,preview', '9.0.x,preview']
+        dotnet: ['8.0.1xx:ga', '8.0.2xx:ga', '8.0.3xx:ga', '8.0.4xx:ga', '8.0.x:preview', '9.0.1xx:ga', '9.0.2xx:preview', '9.0.x:preview']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
@@ -48,13 +48,11 @@ jobs:
 
     - name: Parse .NET version and quality
       id: parse-dotnet
+      shell: pwsh
       run: |
-        DOTNET_VERSION="${{ matrix.dotnet }}"
-        DOTNET_VERSION="${DOTNET_VERSION%,*}"
-        DOTNET_QUALITY="${{ matrix.dotnet }}"
-        DOTNET_QUALITY="${DOTNET_QUALITY#*,}"
-        echo "version=$DOTNET_VERSION" >> $GITHUB_OUTPUT
-        echo "quality=$DOTNET_QUALITY" >> $GITHUB_OUTPUT
+        $parts = "${{ matrix.dotnet }}" -split ":"
+        "dotnet-version=$($parts[0])" >> $env:GITHUB_OUTPUT
+        "dotnet-quality=$($parts[1])" >> $env:GITHUB_OUTPUT
 
     - name: Restore build cache
       id: cache-build
@@ -62,7 +60,7 @@ jobs:
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ steps.setup-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Stop if build cache hit
       if: steps.cache-build.outputs.cache-hit == 'true'
@@ -143,7 +141,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ steps.setup-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}${{ matrix.project-type }}-${{ matrix.configuration }}
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
-        dotnet: ['8.x:ga', '8.x:preview', '9.0.1xx:ga', '9.0.2xx:preview', '9.0.x:preview']
+        dotnet: ['8.x:ga', '8.x:daily', '9.0.1xx:ga', '9.0.2xx:ga', '9.0.3xx:daily', '9.0.x:daily', '9.0.x:ga']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
@@ -49,13 +49,21 @@ jobs:
         "dotnet-version=$($parts[0])" >> $env:GITHUB_OUTPUT
         "dotnet-quality=$($parts[1])" >> $env:GITHUB_OUTPUT
 
+
+    - name: Install .NET For The Test
+      uses: actions/setup-dotnet@v4
+      id: setup-dotnet
+      with:
+        dotnet-version: ${{ steps.parse-dotnet.outputs.dotnet-version }}
+        dotnet-quality: ${{ steps.parse-dotnet.outputs.dotnet-quality }}        
+
     - name: Restore build cache
       id: cache-build
       uses: actions/cache@v4
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Stop if build cache hit
       if: steps.cache-build.outputs.cache-hit == 'true'
@@ -71,12 +79,6 @@ jobs:
 
    
 
-    - name: Install .NET For The Test
-      uses: actions/setup-dotnet@v4
-      id: setup-dotnet
-      with:
-        dotnet-version: ${{ steps.parse-dotnet.outputs.dotnet-version }}
-        dotnet-quality: ${{ steps.parse-dotnet.outputs.dotnet-quality }}
 
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
@@ -140,7 +142,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ steps.parse-dotnet.outputs.dotnet-version }}-${{ steps.parse-dotnet.outputs.dotnet-quality }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ steps.setup-dotnet.outputs.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['9.0.1xx' ] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx' ]
+        dotnet-version: ['9.0.1xx'] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx']
         project-type: ['blazorwasm'] # ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
@@ -126,7 +126,6 @@ jobs:
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
       shell: pwsh
       run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' || 'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' || '' }}
-
 
     - name: Set ref version for Assembly Locator
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,12 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
         dotnet-quality: 'daily' # Use the daily build, so we find potential issues early.
 
+    - name: Install .NET For Engineering
+      uses: actions/setup-dotnet@v4
+      id: setup-dotnet-eng
+      with:
+        dotnet-version: 9.0.200
+
     - name: Configure the dependency to Metalama
       shell: pwsh
       run: ./Build.ps1 dependencies set Metalama BuildServer --branch ${{github.ref_name}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,12 +43,6 @@ jobs:
     # Needed only locally
     #- name: Install PowerShell
     #  uses: cakhanif/action-install-powershell@v1
-
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
     # Restore build cache if available
     - name: Restore build cache
       id: cache-build
@@ -63,6 +57,12 @@ jobs:
       run: |
         echo "Build cache hit, skipping build."
         exit 0
+
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Parse .NET version and quality
       id: parse-dotnet
@@ -129,7 +129,11 @@ jobs:
       shell: pwsh
       run: ./Build.ps1 build --nologo
 
-    # Save build cache after successful build
+    - name: Verify Transformations
+      shell: pwsh
+      run: ./Build.ps1 verify-transformations --nologo
+
+          # Save build cache after successful build
     - name: Save build cache
       if: success()
       uses: actions/cache/save@v4
@@ -137,9 +141,7 @@ jobs:
         path: ./.build-cache
         key: build-${{ matrix.os }}-${{ matrix.dotnet }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
-    - name: Verify Transformations
-      shell: pwsh
-      run: ./Build.ps1 verify-transformations --nologo
+
 
     # - name: Print crash reports
     #   if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Configure the dependency to Metalama
       shell: pwsh
-      run: ./Build.ps1 dependencies set Metalama BuildServer --branch ${{github.ref_name}}
+      run: ./Build.ps1 dependencies set BuildServer Metalama --branch ${{github.ref_name}} --nologo
 
     - name: Set the .NET SDK Version
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx']
+        dotnet-version: ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx', '9.0.2xx']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,10 @@ jobs:
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
       run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
 
+    - name: Install Xcode
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'  && steps.cache-build.outputs.cache-hit != 'true'
+      run: sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+
     - name: Install .NET Workloads
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor')  && steps.cache-build.outputs.cache-hit != 'true'
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['9.0.1xx'] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx']
-        project-type: ['blazorwasm'] # ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
+        dotnet-version: ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx']
+        project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
           - project-type: maui # N/A
@@ -50,12 +50,6 @@ jobs:
             dotnet-version: '9.0.1xx'
           - project-type: maui-blazor # Interceptors not supported before Metalama 2025.0.
             dotnet-version: '9.0.1xx'
-          # - project-type: maui # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
-          #   dotnet-version: '9.0.1xx'
-          # - project-type: maui-blazor # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
-          #   dotnet-version: '9.0.1xx'
-          # - project-type: 'blazorwasm' # ASP.NET Core 9.0 builds act like stable releases right now, resulting in missing packages. TODO: Remove after .NET 9 GA.
-          #   dotnet-version: '9.0.1xx'
       fail-fast: false # Don't stop other jobs if one fails.
 
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['8.0.1xx', '8.0.3xx', '8.0.4xx', '8.0.x', '9.0.1xx', '9.0.2xx', '9.0.x']
+        os: [ubuntu-latest, windows-latest, macos-15]
+        dotnet: ['8.0.1xx,ga', '8.0.2xx,ga', '8.0.3xx,ga', '8.0.4xx,ga', '8.0.x,preview', '9.0.1xx,ga', '9.0.2xx,preview', '9.0.x,preview']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
@@ -56,7 +56,7 @@ jobs:
       with:
         path: |
           ./.build-cache
-        key: build-${{ matrix.os }}-${{ matrix.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ matrix.dotnet }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Stop if build cache hit
       if: steps.cache-build.outputs.cache-hit == 'true'
@@ -64,25 +64,22 @@ jobs:
         echo "Build cache hit, skipping build."
         exit 0
 
-    # Avoid issues with symlinks
-    # Needed only locally
-    #- name: Copy EditorConfig
-    #  uses: canastro/copy-file-action@master
-    #  with:
-    #    source: "eng/style/.editorconfig"
-    #    target: ".editorconfig"
-
-    - name: Install .NET For PostSharp.Engineering
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.2xx # Keep in sync with eng\src\global.json.
+    - name: Parse .NET version and quality
+      id: parse-dotnet
+      run: |
+        DOTNET_VERSION="${{ matrix.dotnet }}"
+        DOTNET_VERSION="${DOTNET_VERSION%,*}"
+        DOTNET_QUALITY="${{ matrix.dotnet }}"
+        DOTNET_QUALITY="${DOTNET_QUALITY#*,}"
+        echo "version=$DOTNET_VERSION" >> $GITHUB_OUTPUT
+        echo "quality=$DOTNET_QUALITY" >> $GITHUB_OUTPUT
 
     - name: Install .NET For The Test
       uses: actions/setup-dotnet@v4
       id: setup-dotnet
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
-        dotnet-quality: 'preview' 
+        dotnet-version: ${{ steps.parse-dotnet.outputs.version }}
+        dotnet-quality: ${{ steps.parse-dotnet.outputs.quality }}
 
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
@@ -138,7 +135,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ./.build-cache
-        key: build-${{ matrix.os }}-${{ matrix.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+        key: build-${{ matrix.os }}-${{ matrix.dotnet }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Verify Transformations
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,12 @@ jobs:
             dotnet-version: '8.0.4xx'
           - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
             dotnet-version: '9.0.1xx'
-          - project-type: maui # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
-            dotnet-version: '9.0.1xx'
-          - project-type: maui-blazor # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
-            dotnet-version: '9.0.1xx'
-          - project-type: 'blazorwasm' # ASP.NET Core 9.0 builds act like stable releases right now, resulting in missing packages. TODO: Remove after .NET 9 GA.
-            dotnet-version: '9.0.1xx'
+          # - project-type: maui # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
+          #   dotnet-version: '9.0.1xx'
+          # - project-type: maui-blazor # MAUI fails on .NET 9 RC2 at the moment: https://github.com/dotnet/sdk/issues/43049
+          #   dotnet-version: '9.0.1xx'
+          # - project-type: 'blazorwasm' # ASP.NET Core 9.0 builds act like stable releases right now, resulting in missing packages. TODO: Remove after .NET 9 GA.
+          #   dotnet-version: '9.0.1xx'
       fail-fast: false # Don't stop other jobs if one fails.
 
     timeout-minutes: 60
@@ -118,10 +118,10 @@ jobs:
       if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
       run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
 
-    - name: Add NuGet Feed # https://github.com/dotnet/sdk/issues/43050 TODO: Remove after .NET 9 GA
-      if: matrix.dotnet-version == '9.0.1xx' && matrix.project-type == 'blazorwasm'
-      shell: pwsh
-      run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n dotnet9 --configfile ./nuget.config
+    # - name: Add NuGet Feed # https://github.com/dotnet/sdk/issues/43050 TODO: Remove after .NET 9 GA
+    #   if: matrix.dotnet-version == '9.0.1xx' && matrix.project-type == 'blazorwasm'
+    #   shell: pwsh
+    #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n dotnet9 --configfile ./nuget.config
 
     - name: Install .NET Workloads
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx', '9.0.2xx']
+        dotnet-version: ['8.0.1xx', '8.0.3xx', '8.0.4xx', '8.0.x', '9.0.1xx', '9.0.2xx', '9.0.x']
         project-type: ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
-          - project-type: maui # N/A
-            dotnet-version: 6.0.1xx
-          - project-type: maui-blazor # N/A
-            dotnet-version: 6.0.1xx
-          - project-type: maui # error XA5207: Could not find android.jar for API level 31. - Won't solve - out of support.
-            dotnet-version: 6.0.4xx
-            os: macos-15
-          - project-type: maui-blazor # error XA5207: Could not find android.jar for API level 31. - Won't solve - out of support.
-            dotnet-version: 6.0.4xx
-            os: macos-15
-          - project-type: blazor # N/A
-            dotnet-version: 6.0.1xx
-          - project-type: blazor # N/A
-            dotnet-version: 6.0.4xx
           - project-type: winforms # N/A
             os: ubuntu-latest
           - project-type: winforms # N/A
@@ -38,18 +24,6 @@ jobs:
             os: ubuntu-latest
           - project-type: wpf # N/A
             os: macos-15
-          - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '8.0.1xx'
-          - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '8.0.3xx'
-          - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '8.0.4xx'
-          - project-type: blazorwasm # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '9.0.1xx'
-          - project-type: maui # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '9.0.1xx'
-          - project-type: maui-blazor # Interceptors not supported before Metalama 2025.0.
-            dotnet-version: '9.0.1xx'
       fail-fast: false # Don't stop other jobs if one fails.
 
     timeout-minutes: 60
@@ -75,6 +49,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Restore build cache if available
+    - name: Restore build cache
+      id: cache-build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./.build-cache
+        key: build-${{ matrix.os }}-${{ matrix.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
+
+    - name: Stop if build cache hit
+      if: steps.cache-build.outputs.cache-hit == 'true'
+      run: |
+        echo "Build cache hit, skipping build."
+        exit 0
+
     # Avoid issues with symlinks
     # Needed only locally
     #- name: Copy EditorConfig
@@ -93,7 +82,7 @@ jobs:
       id: setup-dotnet
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
-        dotnet-quality: 'daily' # Use the daily build, so we find potential issues early.
+        dotnet-quality: 'preview' 
 
     - name: Install .NET For Engineering
       uses: actions/setup-dotnet@v4
@@ -142,6 +131,14 @@ jobs:
     - name: Build
       shell: pwsh
       run: ./Build.ps1 build --nologo
+
+    # Save build cache after successful build
+    - name: Save build cache
+      if: success()
+      uses: actions/cache/save@v4
+      with:
+        path: ./.build-cache
+        key: build-${{ matrix.os }}-${{ matrix.dotnet-version }}-${{ matrix.project-type }}-${{ matrix.configuration }}
 
     - name: Verify Transformations
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15] # Find and replace macos-15 to macos-latest as soon as macos-15 get out of preview.
-        dotnet-version: ['8.0.4xx' ] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx' ]
-        project-type: ['maui', 'maui-blazor'] # ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
+        dotnet-version: ['9.0.1xx' ] # ['6.0.1xx', '6.0.4xx', '8.0.1xx', '8.0.3xx', '8.0.4xx', '9.0.1xx' ]
+        project-type: ['blazorwasm'] # ['console', 'maui', 'maui-blazor', 'mvc', 'razor', 'blazor', 'blazorwasm', 'winforms', 'wpf'] # dotnet new list
         configuration: [Debug]
         exclude:
           - project-type: maui # N/A
@@ -126,6 +126,7 @@ jobs:
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
       shell: pwsh
       run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' || 'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' || '' }}
+
 
     - name: Set ref version for Assembly Locator
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,52 +105,27 @@ jobs:
       shell: pwsh
       run: ./Build.ps1 set-sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --nologo
 
-    # - name: Install Java
-    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
-    #   uses: actions/setup-java@v4
-    #   with:
-    #     distribution: 'microsoft'
-    #     java-version: ${{ matrix.dotnet-version == '6.0.4xx' && '11' || '21' }} # error XA0030: Building with JDK version `21.0.2` is not supported. Please install JDK version `11.0`.
+    - name: Install Java
+      if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'microsoft'
+        java-version: ${{ matrix.dotnet-version == '6.0.4xx' && '11' || '17' }} # error XA0030: Building with JDK version `21.0.2` is not supported. Please install JDK version `11.0`.
 
-    # - name: Install Android SDK
-    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
-    #   uses: android-actions/setup-android@v3
-    #   with:
-    #       cmdline-tools-version: ${{ matrix.dotnet-version == '6.0.4xx' && '9862592' || '10406996' }} # Based on the Java version installed above. See https://github.com/android-actions/setup-android?tab=readme-ov-file#sdk-version-selection
+    - name: Install Android SDK
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
+      uses: android-actions/setup-android@v3
+      with:
+          cmdline-tools-version: ${{ matrix.dotnet-version == '6.0.4xx' && '9862592' || '10406996' }} # Based on the Java version installed above. See https://github.com/android-actions/setup-android?tab=readme-ov-file#sdk-version-selection
   
-    # - name: Install Android SDK Tools
-    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
-    #   run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
+    - name: Install Android SDK Tools
+      if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && matrix.os == 'macos-15'
+      run: sdkmanager "build-tools;32.0.0" "platforms;android-34"
 
-    # - name: Add NuGet Feed # https://github.com/dotnet/sdk/issues/43050 TODO: Remove after .NET 9 GA
-    #   if: matrix.dotnet-version == '9.0.1xx' && matrix.project-type == 'blazorwasm'
-    #   shell: pwsh
-    #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n dotnet9 --configfile ./nuget.config
-
-    # - name: Add .NET 6 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
-    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
-    #   shell: pwsh
-    #   run: dotnet new nugetconfig && dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -n dotnet6 --configfile ./nuget.config
-
-    # - name: Add .NET 7 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
-    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
-    #   shell: pwsh
-    #   run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json -n dotnet7 --configfile ./nuget.config
-
-    # - name: Add .NET 8 NuGet Feeds # https://github.com/dotnet/sdk/issues/29242
-    #   if: (matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor') && (matrix.dotnet-version == '8.0.1xx' || matrix.dotnet-version == '8.0.3xx' || matrix.dotnet-version == '8.0.4xx')
-    #   shell: pwsh
-    #   run: dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json -n dotnet8 --configfile ./nuget.config
-
-    # - name: Install .NET Workloads
-    #   if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
-    #   shell: pwsh
-    #   run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' ||  'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' ||  '' }}
-
-    - name: Install MAUI dependencies
+    - name: Install .NET Workloads
       if: matrix.project-type == 'maui' || matrix.project-type == 'maui-blazor'
       shell: pwsh
-      run: dotnet dotnet tool install -g Redth.Net.Maui.Check && maui-check --fix --non-interactive --ci
+      run: dotnet workload install ${{ matrix.os == 'windows-latest' && 'maui' || 'maui-android' }}${{ matrix.os == 'macos-15' && ' && dotnet workload install maui-ios && dotnet workload install maui-maccatalyst' || '' }}
 
     - name: Set ref version for Assembly Locator
       shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,9 @@
 
     <Import Project="eng\Versions.props"/>
 
+    <PropertyGroup>
+        <!-- The latest version supported by Metalama Compiler may be higher that the latest version supported by Metalama Framework. -->
+        <LangVersion>$(LangMaxVersion)</LangVersion>
+    </PropertyGroup>
+
 </Project>

--- a/eng/AutoUpdatedVersions.props
+++ b/eng/AutoUpdatedVersions.props
@@ -2,7 +2,8 @@
 <Project>
 
     <PropertyGroup>
-        <MetalamaVersion></MetalamaVersion>
+        <!-- This property should never be consumed from the public NuGet feed because the repo is only built as a private test, by design. -->
+        <MetalamaVersion>0.0</MetalamaVersion>
     </PropertyGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
 
     <!-- Set versions of dependencies. -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>2023.2.169</PostSharpEngineeringVersion>
+        <PostSharpEngineeringVersion>2023.2.170</PostSharpEngineeringVersion>
     </PropertyGroup>
 
     <!-- Set the deafult versions of auto-updated dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
 
     <!-- Set versions of dependencies. -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>2023.2.147</PostSharpEngineeringVersion>
+        <PostSharpEngineeringVersion>2023.2.169</PostSharpEngineeringVersion>
     </PropertyGroup>
 
     <!-- Set the deafult versions of auto-updated dependencies -->

--- a/eng/src/BuildMetalamaTestsDotNetSdk.csproj
+++ b/eng/src/BuildMetalamaTestsDotNetSdk.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>Build</AssemblyName>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>latest</LangVersion>

--- a/eng/src/Program.cs
+++ b/eng/src/Program.cs
@@ -6,7 +6,7 @@ using PostSharp.Engineering.BuildTools;
 using PostSharp.Engineering.BuildTools.Build.Model;
 using PostSharp.Engineering.BuildTools.Build.Solutions;
 using PostSharp.Engineering.BuildTools.Dependencies.Definitions;
-using MetalamaDependencies = PostSharp.Engineering.BuildTools.Dependencies.Definitions.MetalamaDependencies.V2024_2;
+using MetalamaDependencies = PostSharp.Engineering.BuildTools.Dependencies.Definitions.MetalamaDependencies.V2025_0;
 
 var product = new Product( MetalamaDependencies.DotNetSdkTests )
 {

--- a/eng/src/global.json
+++ b/eng/src/global.json
@@ -4,6 +4,6 @@
     "rollForward": "patch"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "2023.2.169"
+    "PostSharp.Engineering.Sdk": "2023.2.170"
   }
 }

--- a/eng/src/global.json
+++ b/eng/src/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "9.0.200",
     "rollForward": "patch"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "2023.2.147"
+    "PostSharp.Engineering.Sdk": "2023.2.169"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.303",
-    "rollForward": "disable"
+    "version": "9.0.200",
+    "rollForward": "patch"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "2023.2.169"
+    "PostSharp.Engineering.Sdk": "2023.2.170"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "2023.2.147"
+    "PostSharp.Engineering.Sdk": "2023.2.169"
   }
 }


### PR DESCRIPTION
This PR fixed the .NET SDK matrix runner for 2025.0. It updates the test matrix and adds a caching mechanism to avoid re-running the same builds in case of success.