### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Platform Integration Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/metalama/Metalama.Tests.DotNetSdk/security/code-scanning/3](https://github.com/metalama/Metalama.Tests.DotNetSdk/security/code-scanning/3)

The recommended fix is to add an explicit `permissions` block to this workflow in `.github/workflows/test.yml`. Since the workflow mostly checks out code, restores caches, sets up environments, and runs builds/tests, the minimal required permission is likely `contents: read` for actions like checking out code. No step in the visible snippet appears to require writing to the repository, issues, or pull requests. The permissions block can be placed at the root of the workflow, just below the `name:` line and above the `on:` block, to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
